### PR TITLE
[timed] Replaced deprecated expressions with up-to-date ones JB#59981

### DIFF
--- a/src/lib/event-pimple.cpp
+++ b/src/lib/event-pimple.cpp
@@ -167,7 +167,7 @@ Maemo::Timed::Event::Action * Maemo::Timed::Event::getAction(event_action_pimple
   {
     ea = new Maemo::Timed::Event::Action ;
     ea->p = pa ;
-    pa->ptr = std::auto_ptr<Action> (ea) ;
+    pa->ptr = std::unique_ptr<Action> (ea) ;
   }
   return ea ;
 }
@@ -223,7 +223,7 @@ Maemo::Timed::Event::Button * Maemo::Timed::Event::getButton(event_button_pimple
   {
     eb = new Maemo::Timed::Event::Button ;
     eb->p = pb ;
-    pb->ptr = std::auto_ptr<Button> (eb) ;
+    pb->ptr = std::unique_ptr<Button> (eb) ;
   }
   return eb ;
 }
@@ -309,7 +309,7 @@ Maemo::Timed::Event::Recurrence * Maemo::Timed::Event::getRecurrence(event_recur
   {
     er = new Maemo::Timed::Event::Recurrence ;
     er->p = pr ;
-    pr->ptr = std::auto_ptr<Recurrence> (er) ;
+    pr->ptr = std::unique_ptr<Recurrence> (er) ;
   }
   return er ;
 }

--- a/src/lib/event-pimple.h
+++ b/src/lib/event-pimple.h
@@ -44,7 +44,7 @@ struct Maemo::Timed::event_pimple_t
 struct Maemo::Timed::event_action_pimple_t
 {
   unsigned action_no ;
-  std::auto_ptr<Event::Action> ptr ;
+  std::unique_ptr<Event::Action> ptr ;
   event_io_t *eio ;
   action_io_t *aio() { return & eio->actions[action_no] ; }
 } ;
@@ -52,7 +52,7 @@ struct Maemo::Timed::event_action_pimple_t
 struct Maemo::Timed::event_button_pimple_t
 {
   unsigned button_no ;
-  std::auto_ptr<Event::Button> ptr ;
+  std::unique_ptr<Event::Button> ptr ;
   event_io_t *eio ;
   button_io_t *bio() { return & eio->buttons[button_no] ; }
 } ;
@@ -60,7 +60,7 @@ struct Maemo::Timed::event_button_pimple_t
 struct Maemo::Timed::event_recurrence_pimple_t
 {
   unsigned recurrence_no ;
-  std::auto_ptr<Event::Recurrence> ptr ;
+  std::unique_ptr<Event::Recurrence> ptr ;
   event_io_t *eio ;
   recurrence_io_t *rio() { return & eio->recrs[recurrence_no] ; }
 } ;

--- a/src/server/timed.cpp
+++ b/src/server/timed.cpp
@@ -23,7 +23,7 @@
 **   License along with Timed. If not, see http://www.gnu.org/licenses/   **
 **                                                                        **
 ***************************************************************************/
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <errno.h>
 #include <sys/types.h>


### PR DESCRIPTION
Replaced all instances of std::auto_ptr with std::unique_ptr and all instances of _BSD_SOURCE with _DEFAULT_SOURCE