### PR TITLE
[timed] Add missing DBus requires in the devel package.

### DIFF
--- a/rpm/timed-qt5.spec
+++ b/rpm/timed-qt5.spec
@@ -49,6 +49,7 @@ timedclient - add, modify, remove, and query alarms.
 Summary:    Development package for %{name}
 Requires:   %{name} = %{version}-%{release}
 Requires:   pkgconfig(Qt5Core)
+Requires:   pkgconfig(Qt5DBus)
 
 %description devel
 Header files and shared lib symlink for %{name}.

--- a/src/lib/timed-qt5.pc
+++ b/src/lib/timed-qt5.pc
@@ -1,4 +1,5 @@
 Name: libtimed-qt5
 Description: timed communication library
 Version: 3.6
+Requires: Qt5DBus
 Libs: -ltimed-qt5


### PR DESCRIPTION
The Maemo::Timed::Interface is using QtDBus.

@pvuorela : The pkgconfig is also missing the DBus include path and link, but I don't know how to add it properly...