### PR TITLE
Remove obsolete README

### DIFF
--- a/README
+++ b/README
@@ -1,2 +1,0 @@
-src/ -- Harmattan Qt-based implementation
-debian/ -- packaging stuff


### PR DESCRIPTION
Debian packaging hasn't existed for years, Harmattan is no more and src containing sources should be obvious.